### PR TITLE
Typography & colors cleanup

### DIFF
--- a/docs/sdk/about/resources/colors.md
+++ b/docs/sdk/about/resources/colors.md
@@ -25,7 +25,6 @@ The table below contains all the colors used in the SDK:
 | `screen` | Zero-elevation background color.<br><br>For full-screen mode in `dark` scheme, this color is used as<br>a background color, while bottom sheets inside the SDK will<br>still use the `background` color. In any scheme it will be used<br>for full-screen image galleries<br><br>:material-information:{ .cl-hint } It's actually supposed to be black or _close to black_ <br>in __any scheme__ | :material-square-rounded:{ .cl-screen } `#FF000000` |
 | `neutral` | A neutral background color used for components | :material-square-rounded:{ .cl-neutral } `#FFF2F2F7` |
 | `border` | The color used for component borders | :material-square-rounded:{ .cl-border } `#FFE5E5EA` |
-| `outline` | Blur outlines and checkmark borders | :material-square-rounded:{ .cl-outline } `#FFC7C7CC` |
 | [**Selection**](/sdk/developer/configuration/ui/theme/selection.md) | |
 | `selectionBackground` | Background color for selection snackbar | :material-square-rounded:{ .cl-selection-background } `#FF000000` |
 | [**Error**](/sdk/developer/configuration/ui/theme/error.md) | |
@@ -33,5 +32,3 @@ The table below contains all the colors used in the SDK:
 | `errorPrimary` | Primary color for error text in the snackbar | :material-format-color-text:{ .cl-error-primary } `#FFFFFFFF` |
 | [**ProductBar :octicons-arrow-right-24: Price**](/sdk/developer/configuration/ui/theme/product-bar.md#prices) :fontawesome-regular-eye-slash:{ title="Optional" } | |
 | `discountedPrice` | Color for discounted price text | :material-format-color-text:{ .cl-discounted-price } `#FFFB1010` |
-| [**PowerBar**](/sdk/developer/configuration/ui/theme/powered-by.md) | |
-| `aiuta` | Color for Aiuta branding<br><br>:material-information:{ .cl-hint } This is not a fully customizable color,<br>you can choose between:<br>- `standard` to use the Aiuta brand color and<br>- `primary` to not highlight the Aiuta label. | :material-format-color-text:{ .cl-aiuta } `standard`{ title="#FF4000FF" } |

--- a/docs/sdk/about/resources/typography.md
+++ b/docs/sdk/about/resources/typography.md
@@ -23,9 +23,6 @@ The table below contains all the text styles used in the SDK:
 | `buttonS` | Small buttons |  `13` | `Semibold` | `18` | `-1%` |
 | [**PageBar**](/sdk/developer/configuration/ui/theme/page-bar.md) | |
 | `pageTitle` | Page titles |  `17` | `Medium` | `22` | `-3%` |
-| [**BottomSheet**](/sdk/developer/configuration/ui/theme/bottom-sheet.md) |
-| `iconButton` | Icon buttons |  `17` | `Medium` | `100%` | `-1%` |
-| `chipsButton` | Chip buttons |  `14` | `Medium` | `18` | `0%` |
 | [**ProductBar**](/sdk/developer/configuration/ui/theme/product-bar.md) |
 | `product` | Product names |  `13` | `Regular` | `100%` | `0%` |
 | `brand` | Brand names |  `12` | `Medium` | `100%` | `-1%` |

--- a/docs/sdk/developer/configuration/ui/theme/bottom-sheet.md
+++ b/docs/sdk/developer/configuration/ui/theme/bottom-sheet.md
@@ -12,36 +12,29 @@ Bottom sheet presentation, including grabber appearance and sheet shape for both
 
 ```typescript
 BottomSheetTheme {
-  typography {
-    iconButton: TextStyle // (1)!
-    chipsButton: TextStyle // (2)!
-  }
-
   shapes {
-    bottomSheet: Shape // (3)!
-    chipsButton: Shape // (4)!
+    bottomSheet: Shape // (1)!
+    chipsButton: Shape // (2)!
   }
 
   grabber {
-    width: Number // (5)!
-    height: Number // (6)!
-    topPadding: Number // (7)!
+    width: Number // (3)!
+    height: Number // (4)!
+    topPadding: Number // (5)!
   }
 
   settings {
-    extendDelimitersToTheRight: Bool // (8)!
-    extendDelimitersToTheLeft: Bool // (9)!
+    extendDelimitersToTheRight: Bool // (6)!
+    extendDelimitersToTheLeft: Bool // (7)!
   }
 }
 
 ```
 
-1. Defines the text style for icon buttons within the bottom sheet.
-2. Specifies the text style for chips-style buttons in the bottom sheet interface.
-3. Sets the shape configuration for the bottom sheet container, controlling its visual appearance.
-4. Configures the shape for chips-style buttons, determining their visual style.
-5. Controls the width of the grabber handle used for dragging the bottom sheet.
-6. Determines the height of the grabber handle for bottom sheet interaction.
-7. Sets the vertical padding between the grabber and the top of the bottom sheet.
-8. Controls whether the bottom sheet delimiters extend to the right edge.
-9. Determines whether the bottom sheet delimiters extend to the left edge. 
+1. Sets the shape configuration for the bottom sheet container, controlling its visual appearance.
+2. Configures the shape for chips-style buttons, determining their visual style.
+3. Controls the width of the grabber handle used for dragging the bottom sheet.
+4. Determines the height of the grabber handle for bottom sheet interaction.
+5. Sets the vertical padding between the grabber and the top of the bottom sheet.
+6. Controls whether the bottom sheet delimiters extend to the right edge.
+7. Determines whether the bottom sheet delimiters extend to the left edge. 

--- a/docs/sdk/developer/configuration/ui/theme/color.md
+++ b/docs/sdk/developer/configuration/ui/theme/color.md
@@ -13,16 +13,18 @@ Defines the color scheme, brand colors, and various color states for UI elements
 ```typescript
 ColorTheme {
   scheme: ColorScheme // (1)!
+
   brand: Color // (2)!
   primary: Color // (3)!
   secondary: Color // (4)!
+
   onDark: Color // (5)!
   onLight: Color // (6)!
+  
   background: Color // (7)!
   screen: Color // (8)!
   neutral: Color // (9)!
   border: Color // (10)!
-  outline: Color // (11)!
 }
 ```
 
@@ -89,11 +91,6 @@ ColorTheme {
 
     !!! example ""
         Default ARGB :material-square-rounded:{ .cl-border } `#FFE5E5EA`
-
-11. Color used for blur outlines and checkmark borders.
-
-    !!! example ""
-        Default ARGB :material-square-rounded:{ .cl-outline } `#FFC7C7CC`
 
 
 ### [:material-arrow-up-left:](#color-theme) Color Scheme

--- a/docs/sdk/developer/configuration/ui/theme/powered-by.md
+++ b/docs/sdk/developer/configuration/ui/theme/powered-by.md
@@ -15,24 +15,7 @@ PowerBarTheme {
   strings {
     poweredByAiuta: String // (1)!
   }
-
-  colors {
-    aiuta: PowerBarColorScheme // (2)!
-  }
 }
 ```
 
 1. Defines the text label for the "Powered By Aiuta" branding element in the interface.
-2. Controls the color scheme used to highlight "Aiuta" in the `poweredByAiuta` label.
-
-### [:material-arrow-up-left:](#power-bar) Color Scheme
-
-```typescript
-enum PowerBarColorScheme {
-  standard // (1)!
-  primary // (2)!
-}
-```
-
-1. Uses the default Aiuta-brand color to highlight "Aiuta" in the `poweredByAiuta` label, which is :material-square-rounded:{ .cl-aiuta } `#FF4000FF`
-2. Applies the [`primary` color](color.md) to the entire label without highlighting "Aiuta". 


### PR DESCRIPTION
Typography:

1. `iconButton` -> use `regular`
2. `chipsButton` -> use `subtle`

Colors

1. `outline` -> use `border`
2. powerBar color scheme -> **do not** highlight Aiuta